### PR TITLE
Fix pytest version to 7.3.2 to resolve pytest-lazy-fixture dependency error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# VSCode Configs
+.vscode/

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ description = run the tests with pytest
 package = wheel
 wheel_build_env = .pkg
 deps =
-    pytest>=6
+    pytest==7.3.2
     flake8
     black
     isort


### PR DESCRIPTION
This pull request fixes an error with the package that caused some tests to fail. The deprecated pytest-lazy-fixture library is incompatible with the most recent pytest versions so we need to avoid it being updated. By explicitly setting the version to 7.3.2 we can avoid this issue in the future.

The errors occur in the following files:
```
tests/test_util/test_instances.py @pytest.mark.parametrize: 122
tests/test_util/test_util.py @pytest.mark.parametrize: 38
tests/test_verifier/test_verifier.py @ pytestmark =pytest.mark.parametrize: 12
```

And causes the following error: ```AttributeError: 'CallSpec2' object has no attribute 'funcargs'```

While this is a simple solution, it might not be maintainable in the long run as we will be stuck with pytest version 7.3.2.