### PR TITLE
Add JSON support for VerificationResults

### DIFF
--- a/autoverify/cli/install/installers/verinet/environment.yml
+++ b/autoverify/cli/install/installers/verinet/environment.yml
@@ -56,7 +56,7 @@ dependencies:
       - markupsafe==2.1.3
       - matplotlib==3.7.1
       - mpmath==1.3.0
-      - netron==7.7.3
+      - netron==7.0.0
       - networkx==3.1
       - numpy==1.21.6
       - nvidia-cublas-cu11==11.10.3.66

--- a/autoverify/cli/install/installers/verinet/environment.yml
+++ b/autoverify/cli/install/installers/verinet/environment.yml
@@ -56,7 +56,7 @@ dependencies:
       - markupsafe==2.1.3
       - matplotlib==3.7.1
       - mpmath==1.3.0
-      - netron==7.0.0
+      - netron==7.7.3
       - networkx==3.1
       - numpy==1.21.6
       - nvidia-cublas-cu11==11.10.3.66

--- a/autoverify/cli/main.py
+++ b/autoverify/cli/main.py
@@ -4,13 +4,12 @@ import argparse
 import sys
 
 from autoverify import __version__ as AV_VERSION
-from autoverify.util.verifiers import get_all_complete_verifier_names
-
-from .install import (
+from autoverify.cli.install import (
     check_commit_hashes,
     try_install_verifiers,
     try_uninstall_verifiers,
 )
+from autoverify.util.verifiers import get_all_complete_verifier_names
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:

--- a/autoverify/util/instances.py
+++ b/autoverify/util/instances.py
@@ -66,8 +66,8 @@ class VerificationDataResult:
             self.counter_example = "\n".join(self.counter_example)
 
         return {
-            "network": self.network,
-            "property": self.property,
+            "network": str(self.network),
+            "property": str(self.property),
             "timeout": str(self.timeout),
             "verifier": self.verifier,
             "config": str(self.config),

--- a/autoverify/util/instances.py
+++ b/autoverify/util/instances.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import csv
+import json
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -22,6 +23,7 @@ from autoverify.verifier.verification_result import (
 class VerificationDataResult:
     """_summary_."""
 
+    # TODO: Convert files to path objects
     network: str
     property: str
     timeout: int | None
@@ -30,9 +32,9 @@ class VerificationDataResult:
     success: Literal["OK", "ERR"]
     result: VerificationResultString
     took: float
-    counter_example: str | tuple[str, str] | None
-    stderr: str | None
-    stdout: str | None
+    counter_example: str | tuple[str, str] | None = None
+    stderr: str | None = None
+    stdout: str | None = None
 
     def __post_init__(self):
         """_summary_."""
@@ -57,6 +59,25 @@ class VerificationDataResult:
             self.stderr or "",
             self.stdout or "",
         ]
+
+    def as_json_row(self) -> dict[str, Any]:
+        """Convert data to a json item."""
+        if isinstance(self.counter_example, tuple):
+            self.counter_example = "\n".join(self.counter_example)
+
+        return {
+            "network": self.network,
+            "property": self.property,
+            "timeout": str(self.timeout),
+            "verifier": self.verifier,
+            "config": str(self.config),
+            "success": self.success,
+            "result": self.result,
+            "took": str(self.took),
+            # "counter_example": self.counter_example or "",
+            "stderr": self.stderr or "",
+            "stdout": self.stdout or "",
+        }
 
     @classmethod
     def from_verification_result(
@@ -97,6 +118,30 @@ def csv_append_verification_result(
         writer.writerow(verification_result.as_csv_row())
 
 
+def json_write_verification_result(
+    verification_result: VerificationDataResult, json_path: Path
+):
+    """_summary_."""
+    # Create json file if it does not exist
+    if not json_path.exists():
+        with open(str(json_path.expanduser()), "w") as json_file:
+            json.dump({"instances": []}, json_file)
+
+    # Append to json file
+    with open(str(json_path.expanduser()), "r+") as json_file:
+        try:
+            file_data = json.load(json_file)
+            # Check if file_data is empty
+            if not file_data:
+                file_data = {"instances": []}
+        except json.decoder.JSONDecodeError:
+            file_data = {"instances": []}
+
+        file_data["instances"].append(verification_result.as_json_row())
+        json_file.seek(0)
+        json.dump(file_data, json_file)
+
+
 def read_verification_result_from_csv(
     csv_path: Path,
 ) -> list[VerificationDataResult]:
@@ -107,6 +152,20 @@ def read_verification_result_from_csv(
     for _, row in results_df.iterrows():
         row = row.to_list()
         verification_results.append(VerificationDataResult(*row))
+
+    return verification_results
+
+
+def read_verification_result_from_json(
+    json_path: Path,
+) -> list[VerificationDataResult]:
+    """Reads a verification results json to a list of its dataclass."""
+    results = pd.read_json(json_path)["instances"].tolist()
+
+    verification_results: list[VerificationDataResult] = []
+
+    for res in results:
+        verification_results.append(VerificationDataResult(**res))
 
     return verification_results
 


### PR DESCRIPTION
Changes:
- Add JSON support for VerificationResults: Working with csvs was fine, but to read some of the error messages from a few instances manually to inspect errors was a bit difficult. JSON is more suitable for that.
- Fix relative import
- Improve logger and json converter: Add a little indicator to see how far into the verification batch process the program is in.
