### PR TITLE
make AbCrown executable for CNNs

### DIFF
--- a/autoverify/verifier/complete/abcrown/verifier.py
+++ b/autoverify/verifier/complete/abcrown/verifier.py
@@ -84,7 +84,8 @@ class AbCrown(CompleteVerifier):
         conda activate {self.conda_env_name}
         python abcrown.py --config {str(config)} \
         --results_file {str(result_file)} \
-        --timeout {str(timeout)}
+        --timeout {str(timeout)} \
+        --conv_mode matrix
         """
 
         return run_cmd, result_file


### PR DESCRIPTION
There were problem when executing AbCrown on CNNs. They are solved by including the following line.
The additional argument in the call to ABCrown does not affect the verification of other networks