### PR TITLE
Multi processing

### DIFF
--- a/autoverify/verifier/complete/abcrown/verifier.py
+++ b/autoverify/verifier/complete/abcrown/verifier.py
@@ -48,7 +48,6 @@ class AbCrown(CompleteVerifier):
         # Ideally just keep track of PIDs rather than pkill name matching
         return [
             cwd(self.tool_path / "complete_verifier"),
-            pkill_matches(["python abcrown.py"]),
         ]
 
     def _parse_result(

--- a/autoverify/verifier/complete/nnenum/verifier.py
+++ b/autoverify/verifier/complete/nnenum/verifier.py
@@ -96,7 +96,7 @@ class Nnenum(CompleteVerifier):
         conda activate {self.conda_env_name}
         python -m nnenum.nnenum {str(network)} {str(property)} {str(timeout)} \
         {str(result_file)} \
-        {6} \
+        {str(cpu_count())} \
         {settings_str} \
         {shlex.quote(str(config))} \
         """

--- a/autoverify/verifier/complete/nnenum/verifier.py
+++ b/autoverify/verifier/complete/nnenum/verifier.py
@@ -46,7 +46,6 @@ class Nnenum(CompleteVerifier):
         return [
             cwd(self.tool_path / "src"),
             environment(OPENBLAS_NUM_THREADS="1", OMP_NUM_THREADS="1"),
-            pkill_matches(["python -m nnenum.nnenum"]),
         ]
 
     def _parse_result(
@@ -97,7 +96,7 @@ class Nnenum(CompleteVerifier):
         conda activate {self.conda_env_name}
         python -m nnenum.nnenum {str(network)} {str(property)} {str(timeout)} \
         {str(result_file)} \
-        {str(cpu_count())} \
+        {6} \
         {settings_str} \
         {shlex.quote(str(config))} \
         """

--- a/autoverify/verifier/complete/ovalbab/verifier.py
+++ b/autoverify/verifier/complete/ovalbab/verifier.py
@@ -52,7 +52,6 @@ class OvalBab(CompleteVerifier):
                     find_conda_lib(self.conda_env_name, "libcudart.so.11.0")
                 )
             ),
-            pkill_matches(["python tools/bab_tools/bab_from_vnnlib.py"]),
         ]
 
     def _parse_result(


### PR DESCRIPTION
Multiprocessing execution of the verifiers is not possible with the current setup, as when one verifier process terminates all the others are killed too. This is now resolved by removing the kill methods for all processes with the verifier name.

In addition, the current function for executing subprocesses did not work properly in SLURM execution, as processes there can't be killed using the os.killpg method, because sudo rights are required for it. Now the subprocess execution function is simplified and the timeout is handled by the underlying verification algorithm. This is beneficial too, as now the time for loading conda environments, etc. is not included in the verification time.