### PR TITLE
Update VeriNet installer

### DIFF
--- a/autoverify/cli/install/installers/verinet/environment.yml
+++ b/autoverify/cli/install/installers/verinet/environment.yml
@@ -56,7 +56,7 @@ dependencies:
       - markupsafe==2.1.3
       - matplotlib==3.7.1
       - mpmath==1.3.0
-      - netron==7.0.0
+      - netron==7.7.3
       - networkx==3.1
       - numpy==1.21.6
       - nvidia-cublas-cu11==11.10.3.66


### PR DESCRIPTION
Netron has to be updated in order to make VeriNet work properly