### PR TITLE
Fix portfolio configuration parsing

### DIFF
--- a/autoverify/portfolio/portfolio_runner.py
+++ b/autoverify/portfolio/portfolio_runner.py
@@ -334,9 +334,9 @@ class PortfolioRunner:
                         target_instance = instance
 
                     future = executor.submit(
-                        self._verifiers[cv].verify_instance, 
+                        self._verifiers[cv].verify_instance,
                         target_instance,
-                        config=cv.configuration
+                        config=cv.configuration,
                     )
                     futures[future] = cv
 

--- a/autoverify/portfolio/portfolio_runner.py
+++ b/autoverify/portfolio/portfolio_runner.py
@@ -334,7 +334,9 @@ class PortfolioRunner:
                         target_instance = instance
 
                     future = executor.submit(
-                        self._verifiers[cv].verify_instance, target_instance
+                        self._verifiers[cv].verify_instance, 
+                        target_instance,
+                        config=cv.configuration
                     )
                     futures[future] = cv
 

--- a/autoverify/verifier/verifier.py
+++ b/autoverify/verifier/verifier.py
@@ -1,11 +1,11 @@
 """Base verifier class."""
 
+import logging
 import os
 import signal
 import subprocess
 import threading
 import time
-import logging
 from abc import ABC, abstractmethod
 from contextlib import ExitStack
 from pathlib import Path

--- a/autoverify/verifier/verifier.py
+++ b/autoverify/verifier/verifier.py
@@ -5,6 +5,7 @@ import signal
 import subprocess
 import threading
 import time
+import logging
 from abc import ABC, abstractmethod
 from contextlib import ExitStack
 from pathlib import Path
@@ -187,6 +188,7 @@ class CompleteVerifier(Verifier):
         self._check_instance(network, property)
 
         if config is None:
+            logging.debug("Config is None, continuing with the defaults")
             config = self.default_config
 
         # Tools use different configuration formats and methods, so we let
@@ -236,6 +238,7 @@ class CompleteVerifier(Verifier):
             self._check_instance(instance.network, instance.property)
 
         if config is None:
+            logging.debug("Config is None, continuing with the defaults")
             config = self.default_config
 
         return self._verify_batch(


### PR DESCRIPTION
This PR will fix the parsing of the verifier configurations. Before this PR, the config was not being passed down to the verification thread correctly and automatically used the default configurations of each verifier.
I also added a few logging lines to indicate the usage of a default config.