### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,10 @@ auto-verify config show
 
 Controls how verification tool environments are managed:
 
+- `conda`: Use Conda environments **(recommended)**
 - `auto`: Automatically detect and use the best available option (prefers venv if uv is available)
-- `venv`: Use Python virtual environments with uv (recommended)
-- `conda`: Use Conda environments (legacy support)
+- `venv`: Use Python virtual environments with uv **(experimental feature)**
+
 
 ```bash
 # Set environment strategy to venv


### PR DESCRIPTION
The README mentioned that the conda install variant is legacy, but during development we recognized that conda is working better than python venvs for the intended use case and specifically on SLURM HPC systems. Due to time restrictions and the work involved in setting up and testing python venvs and proper python $PATH mapping on HPC systems, we made the decision to keep conda as the recommended package manager. 